### PR TITLE
Adding a pipeline and datasets, adapting current solvers and datasets

### DIFF
--- a/benchmark_utils/gridsearch_solver.py
+++ b/benchmark_utils/gridsearch_solver.py
@@ -6,6 +6,9 @@ from benchopt.stopping_criterion import SingleRunCriterion
 # - getting requirements info when all dependencies are not installed.
 with safe_import_context() as import_ctx:
     from sklearn.model_selection import GridSearchCV
+    from sklearn.pipeline import Pipeline
+    from sklearn.compose import ColumnTransformer
+    from sklearn.preprocessing import OneHotEncoder
 
 
 # The benchmark solvers must be named `Solver` and
@@ -14,15 +17,21 @@ class GSSolver(BaseSolver):
 
     stopping_criterion = SingleRunCriterion()
 
-    def set_objective(self, X, y):
+    def set_objective(self, X, y, categorical_indicator):
         # Define the information received by each solver from the objective.
         # The arguments of this function are the results of the
         # `Objective.get_objective`. This defines the benchmark's API for
         # passing the objective to the solver.
         # It is customizable for each benchmark.
         self.X, self.y = X, y
+        self.categorical_indicator = categorical_indicator
+        preprocessor = ColumnTransformer([("one_hot", OneHotEncoder(categories="auto", handle_unknown="ignore"),
+                                    [i for i in range(self.X.shape[1]) if self.categorical_indicator[i]]),
+                                    ("numerical", "passthrough",
+                                    [i for i in range(self.X.shape[1]) if not self.categorical_indicator[i]])])
+        model = Pipeline(steps=[("preprocessor", preprocessor), ("model", self.get_model())])
         self.clf = GridSearchCV(
-            self.get_model(), self.parameter_grid
+            model, self.parameter_grid
         )
 
     def run(self, n_iter):

--- a/datasets/KDDCup09_upselling.py
+++ b/datasets/KDDCup09_upselling.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "KDDCup09_upselling"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44186)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/MiniBooNE.py
+++ b/datasets/MiniBooNE.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "MiniBooNE"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44128)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/bank_marketing.py
+++ b/datasets/bank_marketing.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "bank-marketing"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44126)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/california.py
+++ b/datasets/california.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "california"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44090)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/compass.py
+++ b/datasets/compass.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "compass"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44162)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/covertype.py
+++ b/datasets/covertype.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "covertype"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44121)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/covertype_cat.py
+++ b/datasets/covertype_cat.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "covertype_categorical"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44159)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/credit.py
+++ b/datasets/credit.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "credit"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44089)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/electricity.py
+++ b/datasets/electricity.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "electricity"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44120)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/electricity_cat.py
+++ b/datasets/electricity_cat.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "electricity_categorical"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44156)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/eyemovements.py
+++ b/datasets/eyemovements.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "eye_movements"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44130)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/eyemovements_cat.py
+++ b/datasets/eyemovements_cat.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "eye_movements_categorical"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44157)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/higgs.py
+++ b/datasets/higgs.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "Higgs"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44129)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/house_16H.py
+++ b/datasets/house_16H.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "house_16H"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44123)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/iris.py
+++ b/datasets/iris.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    from sklearn.datasets import load_iris
+
+
+class Dataset(BaseDataset):
+
+    name = "iris"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [27]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        X, y = load_iris(
+            return_X_y=True
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+        cat_indicator = [False]*X.shape[1]
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/jannis.py
+++ b/datasets/jannis.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "jannis"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44131)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/kdd_ipums_la_97-small.py
+++ b/datasets/kdd_ipums_la_97-small.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "kdd_ipums_la_97-small"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44124)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/magictelescope.py
+++ b/datasets/magictelescope.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "MagicTelescope"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44125)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/phoneme.py
+++ b/datasets/phoneme.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "phoneme"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44127)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/pol.py
+++ b/datasets/pol.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "pol"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44122)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/rl.py
+++ b/datasets/rl.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "rl"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44160)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/road_safety.py
+++ b/datasets/road_safety.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "road-safety"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44161)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -42,9 +42,11 @@ class Dataset(BaseDataset):
         X_train, X_test, y_train, y_test = train_test_split(
             X, y, test_size=self.test_size, random_state=rng
         )
+        cat_indicator = [False]*X.shape[1]
 
         # The dictionary defines the keyword arguments for `Objective.set_data`
         return dict(
             X_train=X_train, y_train=y_train,
-            X_test=X_test, y_test=y_test
+            X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
         )

--- a/datasets/wine.py
+++ b/datasets/wine.py
@@ -1,0 +1,31 @@
+from benchopt import BaseDataset, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    import openml
+
+
+class Dataset(BaseDataset):
+
+    name = "wine"
+
+    parameters = {
+        'test_size': [0.25],
+        'seed': [42]
+    }
+
+    def get_data(self):
+        rng = np.random.RandomState(self.seed)
+        dataset = openml.datasets.get_dataset(44091)
+        X, y, cat_indicator, attribute_names = dataset.get_data(
+            dataset_format="array", target=dataset.default_target_attribute
+        )
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=rng
+        )
+
+        return dict(
+            X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test,
+            categorical_indicator=cat_indicator
+        )

--- a/objective.py
+++ b/objective.py
@@ -5,6 +5,8 @@ from benchopt import BaseObjective, safe_import_context
 # - getting requirements info when all dependencies are not installed.
 with safe_import_context() as import_ctx:
     from sklearn.dummy import DummyClassifier
+    from sklearn.metrics import balanced_accuracy_score, roc_auc_score
+    import numpy as np
 
 
 # The benchmark objective must be named `Objective` and
@@ -28,12 +30,13 @@ class Objective(BaseObjective):
     # Bump it up if the benchmark depends on a new feature of benchopt.
     min_benchopt_version = "1.3.2"
 
-    def set_data(self, X_train, y_train, X_test, y_test):
+    def set_data(self, X_train, y_train, X_test, y_test, categorical_indicator):
         # The keyword arguments of this function are the keys of the dictionary
         # returned by `Dataset.get_data`. This defines the benchmark's
         # API to pass data. This is customizable for each benchmark.
         self.X_train, self.y_train = X_train, y_train
         self.X_test, self.y_test = X_test, y_test
+        self.categorical_indicator = categorical_indicator
 
     def compute(self, model):
         # The arguments of this function are the outputs of the
@@ -41,12 +44,19 @@ class Objective(BaseObjective):
         # solvers' result. This is customizable for each benchmark.
         score_train = model.score(self.X_train, self.y_train)
         score_test = model.score(self.X_test, self.y_test)
+        bl_acc = balanced_accuracy_score(self.y_test, model.predict(self.X_test))
+        if len(np.unique(self.y_test)) > 2:
+            roc_score = roc_auc_score(self.y_test, model.predict_proba(self.X_test), multi_class='ovr')
+        else:
+            roc_score = roc_auc_score(self.y_test, model.predict_proba(self.X_test)[:, 1])
 
         # This method can return many metrics in a dictionary. One of these
         # metrics needs to be `value` for convergence detection purposes.
         return dict(
             value=score_test,
             score_train=score_train,
+            balanced_accuracy = bl_acc,
+            roc_auc_score = roc_score
         )
 
     def get_one_solution(self):
@@ -63,4 +73,5 @@ class Objective(BaseObjective):
         return dict(
             X=self.X_train,
             y=self.y_train,
+            categorical_indicator = self.categorical_indicator
         )

--- a/solvers/HistBoostTree.py
+++ b/solvers/HistBoostTree.py
@@ -1,0 +1,18 @@
+from benchopt import safe_import_context
+from benchmark_utils.gridsearch_solver import GSSolver
+
+with safe_import_context() as import_ctx:
+    from sklearn.ensemble import HistGradientBoostingClassifier
+
+
+class Solver(GSSolver):
+
+    name = 'HistGradientBoostingClassifier'
+
+    parameter_grid = {
+        'model__max_iter': [100, 1000, 2000],
+        'model__learning_rate': [0.1, 0.2, 0.5, 1]
+    }
+
+    def get_model(self):
+        return HistGradientBoostingClassifier()

--- a/solvers/RandomForest.py
+++ b/solvers/RandomForest.py
@@ -1,0 +1,15 @@
+from benchopt import safe_import_context
+from benchmark_utils.gridsearch_solver import GSSolver
+
+with safe_import_context() as import_ctx:
+    from sklearn.ensemble import RandomForestClassifier
+
+
+class Solver(GSSolver):
+
+    name = 'RandomForest'
+
+    parameter_grid = {'model__n_estimators': [10, 20, 50, 100, 200]}
+
+    def get_model(self):
+        return RandomForestClassifier()

--- a/solvers/logreg_l2.py
+++ b/solvers/logreg_l2.py
@@ -20,7 +20,7 @@ class Solver(GSSolver):
     }
 
     parameter_grid = {
-        'C': [10, 1, .1]
+        'model__C': [10, 1, .1]
     }
 
     def get_model(self):
@@ -34,4 +34,3 @@ class Solver(GSSolver):
         return LogisticRegression(
             penalty=self.penalty, solver=solver, l1_ratio=l1_ratio
         )
-

--- a/solvers/svm.py
+++ b/solvers/svm.py
@@ -16,7 +16,7 @@ class Solver(GSSolver):
     name = 'SVM'
 
     parameter_grid = {
-        'C': [10, 1, .1]
+        'model__C': [10, 1, .1]
     }
 
     def get_model(self):

--- a/solvers/xgboost.py
+++ b/solvers/xgboost.py
@@ -1,0 +1,20 @@
+from benchopt import safe_import_context
+from benchmark_utils.gridsearch_solver import GSSolver
+
+with safe_import_context() as import_ctx:
+    from xgboost import XGBClassifier
+
+
+class Solver(GSSolver):
+
+    name = 'XGBoost'
+
+    requirements = ['py-xgboost']
+
+    parameter_grid = {
+        'model__n_estimators': [100, 1000, 2000],
+        'model__max_depth': range(1, 12)
+    }
+
+    def get_model(self):
+        return XGBClassifier()


### PR DESCRIPTION
## Modifications
- Added a pipeline in `gridsearch_solver.py` with OneHotEncoder.
- Added new metrics (balanced accuracy and ROC AUC).
- Modified the `parameter_grid` names of the solvers to make it work with the pipeline. Also added to the existing dataset a categorical indicator to satisfy the OneHotEncoder process.
- Added new datasets from [Leo's paper](https://hal.science/hal-03723551v2)